### PR TITLE
Avoid warning twice

### DIFF
--- a/R/grad.desc.R
+++ b/R/grad.desc.R
@@ -102,7 +102,7 @@ grad.desc = function(
     gap = abs(FUN(newxy[i + 1, 1], newxy[i + 1, 2]) - FUN(xy[i + 1, 1], xy[i + 1, 2]))
     ani.pause()
     i = i + 1
-    if (i >= nmax) warning('Maximum number of iterations reached!')
+    if (i > nmax) warning('Maximum number of iterations reached!')
   }
   invisible(list(par = newxy[i - 1, ], value = FUN(newxy[i - 1, 1], newxy[i - 1, 2]),
                  iter = i - 1, gradient = grad,


### PR DESCRIPTION
Fix warning twice problem.
when i > nmax, maximum number of iterations reached.
when i == nmax. it should run the ' while loop ' again and not print warning.

Another way, you don't need delete ' = ', just swap the two line, see below

line 104 if (i >= nmax) warning('Maximum number of iterations reached!')
line 105 i = i + 1
