### PR TITLE
Removed supernumary backslash escapes in saveLatex man file.

### DIFF
--- a/man/saveLatex.Rd
+++ b/man/saveLatex.Rd
@@ -110,11 +110,11 @@ saveLatex({
         cex.lab = 0.8, cex.main = 1)
     brownian.motion(pch = 21, cex = 5, col = "red", bg = "yellow", 
         main = "Demonstration of Brownian Motion")
-}, img.name = "BM", ani.opts = "controls,loop,width=0.95\\\\\\\\textwidth", 
+}, img.name = "BM", ani.opts = "controls,loop,width=0.95\\\\textwidth", 
     latex.filename = ifelse(interactive(), "brownian_motion.tex", ""), 
     interval = 0.1, nmax = 10, ani.dev = "pdf", ani.type = "pdf", ani.width = 7, 
-    ani.height = 7, documentclass = paste("\\\\\\\\documentclass{article}", 
-        "\\\\\\\\usepackage[papersize={7in,7in},margin=0.3in]{geometry}", 
+    ani.height = 7, documentclass = paste("\\\\documentclass{article}", 
+        "\\\\usepackage[papersize={7in,7in},margin=0.3in]{geometry}", 
         sep = "\\n"))
 
 ## the PDF graphics output is often too large because it is


### PR DESCRIPTION
At present, the example in the text help page returned by `?saveLatex` doesn't run (at least not for me). I reinstalled the package with the changes above, to check that it fixed the problem, and (again, at least for me) it does.
