### PR TITLE
The hyperlink cannot be expected to work.

### DIFF
--- a/R/g.brownian.motion.R
+++ b/R/g.brownian.motion.R
@@ -16,7 +16,7 @@
 #'
 #'   Due to the ``security settings'' of Adobe Flash player, you might not be
 #'   able to view the generated Flash animation locally, i.e. using an address
-#'   like \url{file:///C:/Temp/index.html}. In this case, you can upload the
+#'   like \samp{file:///C:/Temp/index.html}. In this case, you can upload the
 #'   HTML file to a web server and use the http address to view the Flash file.
 #' @author Yihui Xie
 #' @seealso \code{\link{brownian.motion}}, \code{\link{BM.circle}},

--- a/man/g.brownian.motion.Rd
+++ b/man/g.brownian.motion.Rd
@@ -1,3 +1,4 @@
+% Please edit documentation in R/g.brownian.motion.R
 \name{g.brownian.motion}
 \alias{g.brownian.motion}
 \title{Brownian Motion using Google Visualization API}
@@ -32,7 +33,7 @@ The number of frames is controlled by \code{ani.options('nmax')} as
 
   Due to the ``security settings'' of Adobe Flash player, you might not be
   able to view the generated Flash animation locally, i.e. using an address
-  like \url{file:///C:/Temp/index.html}. In this case, you can upload the
+  like \samp{file:///C:/Temp/index.html}. In this case, you can upload the
   HTML file to a web server and use the http address to view the Flash file.
 }
 \examples{


### PR DESCRIPTION
Use \samp instead of \url

Other hyperlinks are corrected.