### PR TITLE
support avconv on linux, fix cran flags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,15 @@
 Package: animation
 Type: Package
-Title: A gallery of animations in statistics and utilities to create animations
+Title: A Gallery of Animations in Statistics and Utilities to Create Animations
 Version: 2.3.4
-Date: 2014-07-25
-Authors@R: as.person(c(
-    "Barry Rowlingson [ctb]",
-    "Christian Mueller [ctb]",
-    "Lijia Yu [ctb]",
-    "Weicheng Zhu [ctb]",
-    "Yihui Xie [cre, aut] <xie@yihui.name>"
-    ))
+Date: 2015-06-22
+Authors@R: c(
+    person("Barry", "Rowlingson", role= "ctb"),
+    person("Christian", "Mueller",role="ctb"),
+    person("Lijia", "Yu", role="ctb"),
+    person("Weicheng","Zhu",role="ctb"),
+    person("Yihui","Xie", role=c("cre","aut"),email="xie@yihui.name")
+    )
 Maintainer: Yihui Xie <xie@yihui.name>
 Description: This package contains a variety of functions for animations in
     statistics, covering areas such as probability theory, mathematical
@@ -24,7 +24,7 @@ Description: This package contains a variety of functions for animations in
 SystemRequirements: ImageMagick (http://imagemagick.org) or GraphicsMagick
     (http://www.graphicsmagick.org) or LyX (http://www.lyx.org) for saveGIF();
     (PDF)LaTeX for saveLatex(); SWF Tools (http://swftools.org) for saveSWF();
-    FFmpeg (http://ffmpeg.org) for saveVideo()
+    FFmpeg (http://ffmpeg.org) or avconv (https://libav.org/avconv.html) for saveVideo()
 Depends:
     R (>= 2.14.0)
 Suggests:

--- a/R/cv.nfeaturesLDA.R
+++ b/R/cv.nfeaturesLDA.R
@@ -57,7 +57,7 @@ cv.nfeaturesLDA = function(
   data = matrix(rnorm(600), 60), cl = gl(3, 20), k = 5, cex.rg = c(0.5, 3),
   col.av = c('blue', 'red'), ...
 ) {
-  library(MASS)
+  requireNamespace('MASS')
   nmax = min(ncol(data), ani.options('nmax'))
   cl = as.factor(cl)
   dat = data.frame(data, cl)

--- a/R/saveVideo.R
+++ b/R/saveVideo.R
@@ -10,15 +10,17 @@
 #' where \code{interval} comes from \code{ani.options('interval')}, and
 #' \code{ani.type} is from \code{ani.options('ani.type')}. For more details on
 #' the numerous options of FFmpeg, please see the reference.
+#' 
+#' Some linux systems may use the alternate software 'avconv' instead of 'ffmpeg'.  The package will attempt to determine which command is present and set \code{\link{ani.options}('ffmpeg')} to an appropriate default value. This can be overridden by passing in the \code{ffmpeg} argument. 
 #' @param expr the R code to draw (several) plots
 #' @param img.name the file name of the sequence of images to be generated
 #' @param video.name the file name of the output video (e.g.
 #'   \file{animation.mp4} or \file{animation.avi})
 #' @param ffmpeg the command to call FFmpeg (e.g.
-#'   \code{'C:/Software/ffmpeg/bin/ffmpeg.exe'} under Windows); note the full
+#'   \code{'C:/Software/ffmpeg/bin/ffmpeg.exe'} under Windows or 'avconv' on some linux machines); note the full
 #'   path of FFmpeg can be pre-specified in \code{\link{ani.options}('ffmpeg')}
 #' @param other.opts other options to be passed to \code{ffmpeg}, e.g. we can
-#'   specify the bitrate as \code{other.opts = '-b 400k'}
+#'   specify the bitrate as \code{other.opts = '-b 400k'} (The default \code{"-pix_fmt yuv420p"} is a work-around for a bug in some versions of ffmpeg.)
 #' @param ... other arguments to be passed to \code{\link{ani.options}}
 #' @return An integer indicating failure (-1) or success (0) of the converting
 #'   (refer to \code{\link{system}}).
@@ -33,22 +35,23 @@
 #' @export
 #' @example inst/examples/saveVideo-ex.R
 saveVideo = function(
-  expr, video.name = 'animation.mp4', img.name = 'Rplot', ffmpeg = 'ffmpeg',
+  expr, video.name = 'animation.mp4', img.name = 'Rplot', ffmpeg = ani.options('ffmpeg'),
   other.opts = if (grepl('[.]mp4$', video.name)) '-pix_fmt yuv420p', ...
 ) {
   oopt = ani.options(...)
   on.exit(ani.options(oopt))
   owd = setwd(tempdir())
   on.exit(setwd(owd), add = TRUE)
-
-  if (!is.null(ani.options('ffmpeg'))) {
-    ffmpeg = ani.options('ffmpeg')
+  
+  # default ffmpeg command to 'ffmpeg' if not specified
+  if (is.null(ffmpeg)) {
+    ffmpeg = 'ffmpeg'
   }
   if (!grepl('^["\']', ffmpeg)) ffmpeg = shQuote(ffmpeg)
 
   version = try(system(paste(ffmpeg, '-version'), intern = TRUE))
   if (inherits(version, 'try-error')) {
-    warning('The command "', ffmpeg, '" is not available in your system. Please install FFmpeg first: ',
+    warning('The command "', ffmpeg, '" is not available in your system. Please install FFmpeg or avconv first: ',
             ifelse(.Platform$OS.type == 'windows', 'http://ffmpeg.arrozcru.org/autobuilds/',
                    'http://ffmpeg.org/download.html'))
     return()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,4 +9,22 @@
     verbose = TRUE, loop = TRUE, autobrowse = interactive(),
     autoplay = TRUE, use.dev = TRUE
   )
+  
+  # if on a non-windows system, try to determine if ffmpeg or avconv installed
+  # and set default to appropirate command
+  # Windows systems will leave it defaulting to NULL
+  if (.Platform$OS.type != "windows")
+  {
+    # check if ffmpeg installed
+    if (Sys.which('ffmpeg')==''){
+      # can't find ffmpeg, so try avconv
+      if(Sys.which('avconv')!=''){
+        ani.options(ffmpeg = "avconv")
+     } else {
+       ani.options(ffmpeg= "ffmpeg")
+     }
+  } # TODO: if it is windows, should we set it to ani.options(ffmpeg = 'D:/Installer/ffmpeg/bin/ffmpeg.exe') by default?
+}
+
+  
 }

--- a/inst/examples/saveVideo-ex.R
+++ b/inst/examples/saveVideo-ex.R
@@ -1,6 +1,8 @@
-oopts = ani.options(ffmpeg = 'D:/Installer/ffmpeg/bin/ffmpeg.exe')
-## usually Linux users do not need to worry about the path as long as FFmpeg has been installed
-if (.Platform$OS.type != 'windows') ani.options(ffmpeg = 'ffmpeg')
+oopts = if (.Platform$OS.type == 'windows'){
+   ani.options(ffmpeg = 'D:/Installer/ffmpeg/bin/ffmpeg.exe')
+}
+## usually Linux users do not need to worry about the ffmpeg path 
+## as long as FFmpeg or avconv has been installed
 
 saveVideo({
   par(mar = c(3, 3, 1, 0.5), mgp = c(2, 0.5, 0), tcl = -0.3,


### PR DESCRIPTION
this includes suggested I commented for #26.  Idea is when package loads, code in zzz.R will check if on a unix system, if so, check if ffmpeg is on path, if not, check for avconv and set ani.options('ffmpeg') to whichever found.  Modified saveVideo() to so that its default ffmpeg argument is the value of ani.options('ffmpeg').  If NULL, will still try 'ffmpeg'

Todo: should there also be a default value for ffmpeg on windows?

This appears to work fine for me on Ubuntu with avconv installed.  Would be good to double check on other platforms. 

Also made some minor fixes (mostly to DESCRIPTION) for issues flagged by R CMD Check --as-cran  in hopes of a speedy CRAN deployment if this works :-)