### PR TITLE
Fix issue 71, remove extra quote

### DIFF
--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -111,7 +111,7 @@ im.convert = function(
 
   loop = ifelse(isTRUE(ani.options('loop')), 0, ani.options('loop'))
   convert = sprintf(
-    '%s -loop %s %s %s %s', shQuote(convert), loop,
+    '%s -loop %s %s %s %s', convert, loop,
     extra.opts, paste(
       '-delay', interval * 100,
       if (length(interval) == 1) paste(files, collapse = ' ') else files,


### PR DESCRIPTION
Fix issue #71 , remove extra quotes. `gm convert` with extra quote couldn't work on terminal. 
Without extra quotes, `convert` and `gm convert`, they both work well under Fedora, Windows 7 and OS X. 
