### PR TITLE
Changed saveGIF and saveVideo so that they append a "tmp-"

### DIFF
--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -92,10 +92,11 @@ saveGIF = function(
   if (missing(cmd.fun))
     cmd.fun = if (.Platform$OS.type == 'windows') shell else system
   ## convert to animations
-  im.convert(img.files, output = movie.name, convert = convert,
+  output.name <- paste0("tmp-", basename(movie.name))
+  im.convert(img.files, output = output.name, convert = convert,
              cmd.fun = cmd.fun, clean = clean)
 
-  outpath = normalizePath(movie.name) # get the full path
+  outpath = normalizePath(output.name) # get the full path
   setwd(owd)
   file.copy(outpath, movie.name, overwrite = TRUE)
 }

--- a/R/saveVideo.R
+++ b/R/saveVideo.R
@@ -74,14 +74,15 @@ saveVideo = function(
   if (use.dev) dev.off()
 
   ## call FFmpeg
+  bname <- paste0("tmp-", basename(video.name))
   ffmpeg = paste(ffmpeg, '-y', '-r', 1/ani.options('interval'), '-i',
-                 basename(img.fmt), other.opts, basename(video.name))
+                 basename(img.fmt), other.opts, bname)
   message('Executing: ', ffmpeg)
   cmd = system(ffmpeg)
 
   if (cmd == 0) {
     setwd(owd)
-    file.copy(file.path(tempdir(), basename(video.name)), video.name, overwrite = TRUE)
+    file.copy(file.path(tempdir(), bname), video.name, overwrite = TRUE)
     message('\n\nVideo has been created at: ',
             output.path <- normalizePath(video.name))
     auto_browse(output.path)


### PR DESCRIPTION
Changed saveGIF and saveVideo so that they append a "tmp-" in front of the filename saved in the temporary directory, before copying it back to the desired location.

This allows two additional behaviors:

1. each function can now save images to a tmpfile() (otherwise, animation tries to copy the file to itself at the end)
2. saveGIF can save to a file within a directory (see [this issue](https://github.com/dgrtwo/gganimate/issues/3))

Thanks for the excellent package!