### PR TITLE
Fix(bug): auto_browse only open animation in the temporary directory.

### DIFF
--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -77,6 +77,7 @@ im.convert = function(
   files, output = 'animation.gif', convert = c('convert', 'gm convert'),
   cmd.fun = if (.Platform$OS.type == 'windows') shell else system, extra.opts = '', clean = FALSE
 ) {
+  movie.name = basename(output)
   interval = head(ani.options('interval'), length(files))
   convert = match.arg(convert)
   if (convert == 'convert') {
@@ -116,7 +117,7 @@ im.convert = function(
       '-delay', interval * 100,
       if (length(interval) == 1) paste(files, collapse = ' ') else files,
       collapse = ' '),
-    shQuote(output)
+    shQuote(movie.name)
   )
   # there might be an error "the input line is too long", and we need to quote
   # the command; see http://stackoverflow.com/q/682799/559676

--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -92,13 +92,13 @@ saveGIF = function(
   if (missing(cmd.fun))
     cmd.fun = if (.Platform$OS.type == 'windows') shell else system
   ## convert to animations
-  output.name <- paste0("tmp-", basename(movie.name))
-  im.convert(img.files, output = output.name, convert = convert,
+  im.convert(img.files, output = movie.name, convert = convert,
              cmd.fun = cmd.fun, clean = clean)
-
-  outpath = normalizePath(output.name) # get the full path
   setwd(owd)
-  file.copy(outpath, movie.name, overwrite = TRUE)
+  outpath = normalizePath(dirname(movie.name)) # get the full path
+  if (file.path(tempdir(), basename(movie.name))!=movie.name)
+    file.copy(file.path(tempdir(), basename(movie.name)), 
+              movie.name, overwrite = TRUE)
 }
 #' @rdname saveGIF
 saveMovie = saveGIF

--- a/R/saveVideo.R
+++ b/R/saveVideo.R
@@ -74,18 +74,19 @@ saveVideo = function(
   if (use.dev) dev.off()
 
   ## call FFmpeg
-  bname <- paste0("tmp-", basename(video.name))
   ffmpeg = paste(ffmpeg, '-y', '-r', 1/ani.options('interval'), '-i',
-                 basename(img.fmt), other.opts, bname)
+                 basename(img.fmt), other.opts, basename(video.name))
   message('Executing: ', ffmpeg)
   cmd = system(ffmpeg)
 
   if (cmd == 0) {
     setwd(owd)
-    file.copy(file.path(tempdir(), bname), video.name, overwrite = TRUE)
+    if(file.path(tempdir(), basename(video.name))!=video.name)
+      file.copy(file.path(tempdir(), basename(video.name)), video.name, overwrite = TRUE)
     message('\n\nVideo has been created at: ',
             output.path <- normalizePath(video.name))
     auto_browse(output.path)
+
   }
   invisible(cmd)
 }


### PR DESCRIPTION
auto_browse() should open animation in the specific directory
remove prefix name of temporary file
do not copy file from temporary directory to the same directory