### PR TITLE
Fix `loop = FALSE` behaviour

### DIFF
--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -110,7 +110,7 @@ im.convert = function(
     } else convert = ani.options('convert')
   }
 
-  loop = ifelse(isTRUE(ani.options('loop')), 0, ani.options('loop'))
+  loop = ifelse(isTRUE(ani.options('loop')), 0, 1)
   convert = sprintf(
     '%s -loop %s %s %s %s', convert, loop,
     extra.opts, paste(


### PR DESCRIPTION
Setting `loop = FALSE` in `ani.options` does not work, as it forwards `-loop FALSE` instead of the desired `-loop 1` to ImageMagick. This PR fixes this issue and allows `ani.options` to work as supposed in the documentation.

Bug mistakenly documented in `gganimate`: https://github.com/dgrtwo/gganimate/issues/18