### PR TITLE
Avoid doing a basename of the output so that the caller can choose on…

### DIFF
--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -76,7 +76,7 @@ im.convert = function(
   files, output = 'animation.gif', convert = c('convert', 'gm convert'),
   cmd.fun = if (.Platform$OS.type == 'windows') shell else system, extra.opts = '', clean = FALSE
 ) {
-  movie.name = basename(output)
+  movie.name = output
   interval = head(ani.options('interval'), length(files))
   convert = match.arg(convert)
   if (convert == 'convert') {


### PR DESCRIPTION
… which directory to put the output (right now, it's always on the working directory)