### PR TITLE
add extra.opts to saveGIF

### DIFF
--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -60,7 +60,7 @@
 #' @export
 saveGIF = function(
   expr, movie.name = 'animation.gif', img.name = 'Rplot', convert = 'convert',
-  cmd.fun, clean = TRUE, extra.opts="", ...
+  cmd.fun, clean = TRUE, extra.opts = "", ...
 ) {
   oopt = ani.options(...)
   on.exit(ani.options(oopt))

--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -36,6 +36,7 @@
 #' @param cmd.fun a function to invoke the OS command; by default
 #'   \code{\link{system}}
 #' @param clean whether to delete the individual image frames
+#' @param extra.opts additional options passed to \code{\link{im.convert}}
 #' @param \dots other arguments passed to \code{\link{ani.options}}, e.g.
 #'   \code{ani.height} and \code{ani.width}, ...
 #' @return The command for the conversion (see \code{\link{im.convert}}).
@@ -59,7 +60,7 @@
 #' @export
 saveGIF = function(
   expr, movie.name = 'animation.gif', img.name = 'Rplot', convert = 'convert',
-  cmd.fun, clean = TRUE, ...
+  cmd.fun, clean = TRUE, extra.opts="", ...
 ) {
   oopt = ani.options(...)
   on.exit(ani.options(oopt))
@@ -95,10 +96,10 @@ saveGIF = function(
     cmd.fun = if (.Platform$OS.type == 'windows') shell else system
   ## convert to animations
   im.convert(img.files, output =  path.expand(movie.name), convert = convert,
-             cmd.fun = cmd.fun, clean = clean)
+             cmd.fun = cmd.fun, clean = clean, extra.opts = extra.opts)
   setwd(owd)
   if (!grepl(tempdir(),movie.name,fixed = T)){
-    file.copy(file.path(tempdir(), basename(movie.name)), 
+    file.copy(file.path(tempdir(), basename(movie.name)),
               path.expand(movie.name), overwrite = TRUE)
     # auto_browse(path.expand(movie.name))
   }

--- a/inst/examples/spinner-ex.R
+++ b/inst/examples/spinner-ex.R
@@ -1,27 +1,26 @@
-library(scales) # for the alpha() function
-
-t <- seq(0, 2*pi, length.out=201L)[-1L]
+t <- seq(0, 2*pi, length.out = 260L)[-1L]
 x <- cos(3*t); y <- sin(2*t)
-opacity <- seq(0, 1, length.out=length(t)-3L)
+opacity <- format(as.hexmode(0:255), width = 2)
+pinks <- paste0("#FFC0CB", opacity)
 fplot <- function(i){
-  par(mar=c(0,0,0,0))
-  plot(x, y, type="n", axes=FALSE, xlab=NA, ylab=NA)
-  j <- (c(i, i+1, i+2) %% 200L) + 1L
+  par(mar = c(0,0,0,0))
+  plot(x, y, type = "n", axes = FALSE, xlab = NA, ylab = NA)
+  j <- (c(i, i+1, i+2) %% 259L) + 1L
   ii <- i+3
-  points(x[-j][(ii:(196+ii))%%200+1], y[-j][(ii:(196+ii))%%200+1],
+  points(x[-j][(ii:(255+ii))%%259+1], y[-j][(ii:(255+ii))%%259+1],
          pch = 19, cex = 1.5,
-         col = alpha("pink", opacity))
-  points(x[j], y[j], col=alpha("red", 0.5), pch=19, cex=c(1.5, 2, 2.5))
-  text(0, 0, "Calculating...", cex=4, font = 4)
+         col = pinks)
+  points(x[j], y[j], col = "#FF000080", pch = 19, cex = c(1.5, 2, 2.5))
+  text(0, 0, "Calculating...", cex = 4, font = 4)
 }
 
 saveGIF(
   {
-    for(i in 1:200) fplot(i)
+    for(i in 1:259) fplot(i)
   },
   movie.name = "spinner.gif",
-  interval=0.025, ani.width=500, ani.height=500,
-  ani.dev = function(...) png(bg="transparent", ...),
+  interval = 0.025, ani.width = 500, ani.height = 500,
+  ani.dev = function(...) png(bg = "transparent", ...),
   extra.opts = "-coalesce -dispose previous"
 )
 

--- a/inst/examples/spinner-ex.R
+++ b/inst/examples/spinner-ex.R
@@ -1,0 +1,27 @@
+library(scales) # for the alpha() function
+
+t <- seq(0, 2*pi, length.out=201L)[-1L]
+x <- cos(3*t); y <- sin(2*t)
+opacity <- seq(0, 1, length.out=length(t)-3L)
+fplot <- function(i){
+  par(mar=c(0,0,0,0))
+  plot(x, y, type="n", axes=FALSE, xlab=NA, ylab=NA)
+  j <- (c(i, i+1, i+2) %% 200L) + 1L
+  ii <- i+3
+  points(x[-j][(ii:(196+ii))%%200+1], y[-j][(ii:(196+ii))%%200+1],
+         pch = 19, cex = 1.5,
+         col = alpha("pink", opacity))
+  points(x[j], y[j], col=alpha("red", 0.5), pch=19, cex=c(1.5, 2, 2.5))
+  text(0, 0, "Calculating...", cex=4, font = 4)
+}
+
+saveGIF(
+  {
+    for(i in 1:200) fplot(i)
+  },
+  movie.name = "spinner.gif",
+  interval=0.025, ani.width=500, ani.height=500,
+  ani.dev = function(...) png(bg="transparent", ...),
+  extra.opts = "-coalesce -dispose previous"
+)
+


### PR DESCRIPTION
The `saveGIF` function now has the argument `extra.opts` which is passed to `im.convert`. An example is given: `inst/examples/spinner-ex.R`.