### PR TITLE
Using magick as default gif converter

### DIFF
--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -92,12 +92,22 @@ im.convert = function(
     } else convert = ani.options('convert')
     if (!length(grep('ImageMagick', version))) {
       message('I cannot find ImageMagick with convert = ', shQuote(convert))
-      if (.Platform$OS.type != 'windows' || is.null(convert <- find_magic())) {
-        warning('Please install ImageMagick first or put its bin path into the system PATH variable')
-        return()
+      convert_switch=ifelse(convert=='convert',"magick","convert")
+      try(version <- cmd.fun(sprintf('%s --version', convert_switch), intern = TRUE))
+      if (!length(grep('ImageMagick', version))) {
+        message('I also cannot find ImageMagick with convert = ', shQuote(convert_switch))
+        if (.Platform$OS.type != 'windows' || is.null(convert <- find_magic())) {
+          warning('Please install ImageMagick first or put its bin path into the system PATH variable')
+          return()
+        }
+      }else{
+        message('I find ImageMagick with convert = ', shQuote(convert_switch),". I will use " ,
+                shQuote(convert_switch)," instead of ", shQuote(convert),"!")
+        convert=convert_switch
       }
     }
-  } else {
+  } 
+  else {
     ## GraphicsMagick
     version = ''
     if (!is.null(ani.options('convert')))

--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -10,7 +10,7 @@
 #'   containing wildcards (e.g. \file{Rplot*.png})
 #' @param output the file name of the output (with proper extensions, e.g.
 #'   \code{gif})
-#' @param convert the \command{convert} command; it must be either
+#' @param convert the \command{convert} command; it must be \code{'magick'},
 #'   \code{'convert'} or \code{'gm convert'}; and it can be pre-specified as an
 #'   option in \code{\link{ani.options}('convert')}, e.g. (Windows users)
 #'   \code{ani.options(convert = 'c:/program

--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -76,13 +76,13 @@
 #'   GraphicsMagick: \url{http://www.graphicsmagick.org}
 #' @export
 im.convert = function(
-  files, output = 'animation.gif', convert = c('convert', 'gm convert'),
+  files, output = 'animation.gif', convert = c('magick','convert', 'gm convert'),
   cmd.fun = if (.Platform$OS.type == 'windows') shell else system, extra.opts = '', clean = FALSE
 ) {
   movie.name = output
   interval = head(ani.options('interval'), length(files))
-  convert = match.arg(convert)
-  if (convert == 'convert') {
+  convert = match.arg(convert,c('magick','convert', 'gm convert'))
+  if (convert == 'convert' || convert == "magick") {
     version = ''
     if (!is.null(ani.options('convert'))) {
       try(version <- cmd.fun(sprintf('%s --version', shQuote(ani.options('convert'))), intern = TRUE))

--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -62,7 +62,7 @@
 #'   GraphicsMagick: \url{http://www.graphicsmagick.org}
 #' @export
 saveGIF = function(
-  expr, movie.name = 'animation.gif', img.name = 'Rplot', convert = 'convert',
+  expr, movie.name = 'animation.gif', img.name = 'Rplot', convert = 'magick',
   cmd.fun, clean = TRUE, extra.opts = "", ...
 ) {
   oopt = ani.options(...)

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -5,9 +5,9 @@
 \alias{gm.convert}
 \title{A wrapper for the `convert' utility of ImageMagick or GraphicsMagick}
 \usage{
-im.convert(files, output = "animation.gif", convert = c("convert", "gm convert"), 
-    cmd.fun = if (.Platform$OS.type == "windows") shell else system, extra.opts = "", 
-    clean = FALSE)
+im.convert(files, output = "animation.gif", convert = c("magick", "convert", 
+    "gm convert"), cmd.fun = if (.Platform$OS.type == "windows") shell else system, 
+    extra.opts = "", clean = FALSE)
 
 gm.convert(..., convert = "gm convert")
 }
@@ -18,7 +18,7 @@ containing wildcards (e.g. \file{Rplot*.png})}
 \item{output}{the file name of the output (with proper extensions, e.g.
 \code{gif})}
 
-\item{convert}{the \command{convert} command; it must be either
+\item{convert}{the \command{convert} command; it must be \code{'magick'},
 \code{'convert'} or \code{'gm convert'}; and it can be pre-specified as an
 option in \code{\link{ani.options}('convert')}, e.g. (Windows users)
 \code{ani.options(convert = 'c:/program

--- a/man/saveGIF.Rd
+++ b/man/saveGIF.Rd
@@ -6,10 +6,10 @@
 \title{Convert images to a single animation file (typically GIF) using ImageMagick
 or GraphicsMagick}
 \usage{
-saveGIF(expr, movie.name = "animation.gif", img.name = "Rplot", convert = "convert", 
+saveGIF(expr, movie.name = "animation.gif", img.name = "Rplot", convert = "magick", 
     cmd.fun, clean = TRUE, extra.opts = "", ...)
 
-saveMovie(expr, movie.name = "animation.gif", img.name = "Rplot", convert = "convert", 
+saveMovie(expr, movie.name = "animation.gif", img.name = "Rplot", convert = "magick", 
     cmd.fun, clean = TRUE, extra.opts = "", ...)
 }
 \arguments{


### PR DESCRIPTION
A simple way to detect imagemagick converter, avoid to use magick package(issue #85)
1. Using magick by default. We can use magick in any OS with imagemagick version > 7.0
2. When the program cannot find magick, then it will try to find convert (imagemagick version < 7.0)
  2.1 if program find convert, then it will use convert in lieu of magick
  2.2 if program cannot find convert, the program will stop runnig and report the error message.


