### PR TITLE
Customizing image filename's number #107

### DIFF
--- a/R/ani.options.R
+++ b/R/ani.options.R
@@ -23,6 +23,10 @@
 #'   if a positive integer. Also used for units other than the default,
 #'   and to convert points to pixels.;
 #'   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
+#'   
+#'   \time{imgnfmt}{ Customizing image number format, 
+#'   it allows user to define the C-style number format for output image.
+#'   }
 #'
 #'   \item{imgdir}{character: the name of the directory (a relative path) for
 #'   images when creating HTML animation pages; default to be \code{'images'}.}

--- a/R/ani.options.R
+++ b/R/ani.options.R
@@ -27,7 +27,7 @@
 #'   \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
 #'   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
 #'   \code{\link{saveSWF}} is not included, 
-#'   it allows user to define the C-style number format for output image. 
+#'   it allows user to define the C-style string format for output image. 
 #'   }
 #'
 #'   \item{imgdir}{character: the name of the directory (a relative path) for

--- a/R/ani.options.R
+++ b/R/ani.options.R
@@ -24,8 +24,10 @@
 #'   and to convert points to pixels.;
 #'   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
 #'   
-#'   \time{imgnfmt}{ Customizing image number format, 
-#'   it allows user to define the C-style number format for output image.
+#'   \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
+#'   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
+#'   \code{\link{saveSWF}} is not included, 
+#'   it allows user to define the C-style number format for output image. 
 #'   }
 #'
 #'   \item{imgdir}{character: the name of the directory (a relative path) for

--- a/R/ani.options.R
+++ b/R/ani.options.R
@@ -24,7 +24,7 @@
 #'   and to convert points to pixels.;
 #'   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
 #'   
-#'   \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
+#'   \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
 #'   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
 #'   \code{\link{saveSWF}} is not included, 
 #'   it allows user to define the C-style string format for output image. 

--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -82,7 +82,7 @@ saveGIF = function(
   ## draw the plots and record them in image files
   ani.dev = ani.options('ani.dev')
   if (is.character(ani.dev)) ani.dev = get(ani.dev)
-  img.fmt = paste(img.name, '%d.', file.ext, sep = '')
+  img.fmt = paste(img.name, ani.options('imgnfmt'), '.', file.ext, sep = '')
 
   if ((use.dev <- ani.options('use.dev'))){
     if (any(grepl(ani.options('ani.dev'), c("png", "bmp", "jpeg", "tiff")))){

--- a/R/saveHTML.R
+++ b/R/saveHTML.R
@@ -130,7 +130,7 @@ saveHTML = function(
   imgdir = ani.options('imgdir')
   dir.create(imgdir, showWarnings = FALSE, recursive = TRUE)
 
-  img.fmt = file.path(imgdir, paste(img.name, '%d', '.', ani.type, sep = ''))
+  img.fmt = file.path(imgdir, paste(img.name, ani.options('imgnfmt'), '.', ani.type, sep = ''))
   ani.options(img.fmt = img.fmt)
   if ((use.dev <- ani.options('use.dev')))
     ani.dev(img.fmt, width = ani.options('ani.width'), height = ani.options('ani.height'))
@@ -182,7 +182,7 @@ saveHTML = function(
   ani.options(nmax = imglen)
   imglist = file.path(
     ani.options('imgdir'),
-    sprintf(paste(img.name, '%d.', ani.type, sep = ''), seq_len(imglen))
+    sprintf(paste(img.name, ani.options('imgnfmt'), '.', ani.type, sep = ''), seq_len(imglen))
   )
   if (!navigator) single.opts = remove_navigator(single.opts)
   js.temp = sprintf(

--- a/R/saveLatex.R
+++ b/R/saveLatex.R
@@ -100,7 +100,7 @@ saveLatex = function(
         if (all(c('prefix.string', 'label') %in% names(chunkopts))) {
           ## yes, I'm in Sweave w.p. 95%
           img.name = paste(chunkopts$prefix.string, chunkopts$label, sep = '-')
-          ani.options(img.fmt = paste(img.name, '%d.', file.ext, sep = ''))
+          ani.options(img.fmt = paste(img.name, ani.options('imgnfmt'), '.', file.ext, sep = ''))
           in.sweave = TRUE
           break
         }
@@ -111,7 +111,7 @@ saveLatex = function(
   interval = ani.options('interval')
   ## generate the image frames
   ani.dev = ani.options('ani.dev')
-  num = ifelse(file.ext == 'pdf' && use.dev, '', '%d')
+  num = ifelse(file.ext == 'pdf' && use.dev, '', ani.options('imgnfmt'))
   img.fmt = sprintf('%s%s.%s', img.name, num, file.ext)
   if (!in.sweave)
     ani.options(img.fmt = img.fmt)

--- a/R/saveVideo.R
+++ b/R/saveVideo.R
@@ -69,7 +69,7 @@ saveVideo = function(
   interval = ani.options('interval')
   if (is.character(ani.dev)) ani.dev = get(ani.dev)
 
-  num = ifelse(file.ext == 'pdf', '', '%d')
+  num = ifelse(file.ext == 'pdf', '', ani.options('imgnfmt'))
   unlink(paste(img.name, '*.', file.ext, sep = ''))
   img.fmt = paste(img.name, num, '.', file.ext, sep = '')
   img.fmt = file.path(tempdir(), img.fmt)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,7 +2,7 @@
   options(demo.ask = FALSE, example.ask = FALSE)
   .ani.env$.ani.opts = list(
     interval = 1, nmax = 50, ani.width = 480, ani.height = 480, ani.res = NA, # ani.bg = 'white',
-    imgdir = 'images', ani.type = 'png', ani.dev = 'png',
+    imgdir = 'images', ani.type = 'png', ani.dev = 'png', imgnfmt = "%d",
     title = 'Animations Using the R Language',
     description = paste('Animations generated in', R.version.string,
                         'using the package animation'),

--- a/man/ani.options.Rd
+++ b/man/ani.options.Rd
@@ -65,7 +65,7 @@ Please note that \code{nmax} is not always equal to the number of
   and to convert points to pixels.;
   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
   
-  \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
+  \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
   \code{\link{saveSWF}} is not included, 
   it allows user to define the C-style string format for output image. 

--- a/man/ani.options.Rd
+++ b/man/ani.options.Rd
@@ -64,6 +64,12 @@ Please note that \code{nmax} is not always equal to the number of
   if a positive integer. Also used for units other than the default,
   and to convert points to pixels.;
   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
+  
+  \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
+  \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
+  \code{\link{saveSWF}} is not included, 
+  it allows user to define the C-style number format for output image. 
+  }
 
   \item{imgdir}{character: the name of the directory (a relative path) for
   images when creating HTML animation pages; default to be \code{'images'}.}

--- a/man/ani.options.Rd
+++ b/man/ani.options.Rd
@@ -68,7 +68,7 @@ Please note that \code{nmax} is not always equal to the number of
   \time{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
   \code{\link{saveSWF}} is not included, 
-  it allows user to define the C-style number format for output image. 
+  it allows user to define the C-style string format for output image. 
   }
 
   \item{imgdir}{character: the name of the directory (a relative path) for


### PR DESCRIPTION
New parameter for ani.option based on #107, customizing image filename's number.
Default is `Rplot%d.png`, some users want to change it to `Rplot%02d.png`.
