### PR TITLE
use shQuote to solve the special characters problem in filename #110

### DIFF
--- a/R/pdftk.R
+++ b/R/pdftk.R
@@ -29,10 +29,7 @@ pdftk = function(input, operation = NULL, output, other.opts = 'compress dont_as
     auto.output = missing(output) && length(input) == 1 && file.exists(input)
     if (auto.output)
       output = file.path(dirname(input), paste('output', basename(input), sep = '-'))
-    # if input has special characters in it, the function will fail without
-    # placing them in quotes and escaping possible quotes
-    input =  gsub(pattern = "'",replacement = "\\\\'", x = input)
-    cmd = paste(pdftk.path, paste0("'",input,"'", collapse = ' '),
+    cmd = paste(pdftk.path, paste(shQuote(input), collapse = ' '),
                 operation, sprintf('output %s', output), other.opts)
     message('* Pdftk is running... \n* ', cmd)
     status = system(cmd)


### PR DESCRIPTION
#110 use shQuote to solve the special characters problem in filenames

I need test it when I find `pdftk` package for my OS..