### PR TITLE
Support converting to gif using 'magick' package, closes #85

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,8 @@ SystemRequirements: ImageMagick (http://imagemagick.org) or GraphicsMagick
     saveVideo()
 Depends:
     R (>= 2.14.0)
+Imports:
+    magick
 Suggests:
     MASS,
     class,

--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,11 @@
 
 NEW FEATURES
 
-  o add a new option ani.res() to ani.options(), to control the resolution of png, 
+  o add a new option ani.res() to ani.options(), to control the resolution of png,
   jepg, bmp and tiff images when using saveGIF() (#99).
+
+  o saveGIF() and im.convert() now support converting using the 'magick' R package
+  which does not require shelling out to external software.
 
 		  CHANGES IN animation VERSION 2.5
 

--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -70,7 +70,7 @@
 #' @author Yihui Xie
 #' @family utilities
 #' @references Examples at \url{https://yihui.name/animation/example/im-convert/}
-#' 
+#'
 #'   ImageMagick: \url{http://www.imagemagick.org/script/convert.php}
 #'
 #'   GraphicsMagick: \url{http://www.graphicsmagick.org}
@@ -81,7 +81,11 @@ im.convert = function(
 ) {
   movie.name = output
   interval = head(ani.options('interval'), length(files))
+  loop = ifelse(isTRUE(ani.options('loop')), 0, ani.options('loop'))
   convert = match.arg(convert,c('magick','convert', 'gm convert'))
+  if (convert == 'magick' && requireNamespace('magick', quietly = TRUE)){
+    return(magick.convert(files = files, output = output, loop = loop, interval = interval))
+  }
   if (convert == 'convert' || convert == "magick") {
     version = ''
     if (!is.null(ani.options('convert'))) {
@@ -106,7 +110,7 @@ im.convert = function(
         convert=convert_switch
       }
     }
-  } 
+  }
   else {
     ## GraphicsMagick
     version = ''
@@ -122,7 +126,6 @@ im.convert = function(
     } else convert = ani.options('convert')
   }
 
-  loop = ifelse(isTRUE(ani.options('loop')), 0, ani.options('loop'))
   convert = sprintf(
     '%s -loop %s %s %s %s', convert, loop,
     extra.opts, paste(
@@ -157,4 +160,10 @@ im.convert = function(
 #' @export
 gm.convert = function(..., convert = 'gm convert') {
   im.convert(..., convert = convert)
+}
+
+magick.convert <- function(files, output, interval = 1, loop = 0){
+  img <- magick::image_read(files, strip = TRUE)
+  anim <- magick::image_animate(img, loop = loop, fps = 100 / as.integer(interval * 100))
+  magick::image_write(anim, path = output)
 }

--- a/R/im.convert.R
+++ b/R/im.convert.R
@@ -84,65 +84,69 @@ im.convert = function(
   loop = ifelse(isTRUE(ani.options('loop')), 0, ani.options('loop'))
   convert = match.arg(convert,c('magick','convert', 'gm convert'))
   if (convert == 'magick' && requireNamespace('magick', quietly = TRUE)){
-    return(magick.convert(files = files, output = output, loop = loop, interval = interval))
-  }
-  if (convert == 'convert' || convert == "magick") {
-    version = ''
-    if (!is.null(ani.options('convert'))) {
-      try(version <- cmd.fun(sprintf('%s --version', shQuote(ani.options('convert'))), intern = TRUE))
-    }
-    if (!length(grep('ImageMagick', version))) {
-      try(version <- cmd.fun(sprintf('%s --version', convert), intern = TRUE))
-    } else convert = ani.options('convert')
-    if (!length(grep('ImageMagick', version))) {
-      message('I cannot find ImageMagick with convert = ', shQuote(convert))
-      convert_switch=ifelse(convert=='convert',"magick","convert")
-      try(version <- cmd.fun(sprintf('%s --version', convert_switch), intern = TRUE))
+    dispose_opt <- regmatches(regexpr(pattern = "-dispose\\s+\\S+", text = extra.opts), x = extra.opts)
+    dispose <- gsub("-dispose ", "", dispose_opt)
+    magick.convert(files = files, output = output, loop = loop, interval = interval, dispose = dispose)
+    cmd <- 0
+  } else {
+    if (convert == 'convert' || convert == "magick") {
+      version = ''
+      if (!is.null(ani.options('convert'))) {
+        try(version <- cmd.fun(sprintf('%s --version', shQuote(ani.options('convert'))), intern = TRUE))
+      }
       if (!length(grep('ImageMagick', version))) {
-        message('I also cannot find ImageMagick with convert = ', shQuote(convert_switch))
-        if (.Platform$OS.type != 'windows' || is.null(convert <- find_magic())) {
-          warning('Please install ImageMagick first or put its bin path into the system PATH variable')
+        try(version <- cmd.fun(sprintf('%s --version', convert), intern = TRUE))
+      } else convert = ani.options('convert')
+      if (!length(grep('ImageMagick', version))) {
+        message('I cannot find ImageMagick with convert = ', shQuote(convert))
+        convert_switch=ifelse(convert=='convert',"magick","convert")
+        try(version <- cmd.fun(sprintf('%s --version', convert_switch), intern = TRUE))
+        if (!length(grep('ImageMagick', version))) {
+          message('I also cannot find ImageMagick with convert = ', shQuote(convert_switch))
+          if (.Platform$OS.type != 'windows' || is.null(convert <- find_magic())) {
+            warning('Please install ImageMagick first or put its bin path into the system PATH variable')
+            return()
+          }
+        }else{
+          message('I find ImageMagick with convert = ', shQuote(convert_switch),". I will use " ,
+                  shQuote(convert_switch)," instead of ", shQuote(convert),"!")
+          convert=convert_switch
+        }
+      }
+    }
+    else {
+      ## GraphicsMagick
+      version = ''
+      if (!is.null(ani.options('convert')))
+        try(version <- cmd.fun(sprintf('%s -version', shQuote(ani.options('convert'))), intern = TRUE))
+      if (!length(grep('GraphicsMagick', version))) {
+        try(version <- cmd.fun(sprintf('%s -version', convert), intern = TRUE))
+        if (!length(grep('GraphicsMagick', version))) {
+          warning('I cannot find GraphicsMagick with convert = ', shQuote(convert),
+                  '; you may have to put the path of GraphicsMagick in the PATH variable.')
           return()
         }
-      }else{
-        message('I find ImageMagick with convert = ', shQuote(convert_switch),". I will use " ,
-                shQuote(convert_switch)," instead of ", shQuote(convert),"!")
-        convert=convert_switch
-      }
+      } else convert = ani.options('convert')
     }
-  }
-  else {
-    ## GraphicsMagick
-    version = ''
-    if (!is.null(ani.options('convert')))
-      try(version <- cmd.fun(sprintf('%s -version', shQuote(ani.options('convert'))), intern = TRUE))
-    if (!length(grep('GraphicsMagick', version))) {
-      try(version <- cmd.fun(sprintf('%s -version', convert), intern = TRUE))
-      if (!length(grep('GraphicsMagick', version))) {
-        warning('I cannot find GraphicsMagick with convert = ', shQuote(convert),
-                '; you may have to put the path of GraphicsMagick in the PATH variable.')
-        return()
-      }
-    } else convert = ani.options('convert')
-  }
 
-  convert = sprintf(
-    '%s -loop %s %s %s %s', convert, loop,
-    extra.opts, paste(
-      '-delay', interval * 100,
-      if (length(interval) == 1) paste(files, collapse = ' ') else files,
-      collapse = ' '),
-    shQuote(movie.name)
-  )
-  # there might be an error "the input line is too long", and we need to quote
-  # the command; see http://stackoverflow.com/q/682799/559676
-  if (.Platform$OS.type == 'windows') convert = sprintf('"%s"', convert)
-  message('Executing: ', strwrap(convert, exdent = 4, prefix = '\n'))
-  if (interactive()) flush.console()
-  cmd = cmd.fun(convert)
-  ## if fails on Windows using shell(), try system() instead of shell()
-  if (cmd != 0 && .Platform$OS.type == 'windows' && identical(cmd.fun, shell)) {
-    cmd = system(convert)
+    convert = sprintf(
+      '%s -loop %s %s %s %s', convert, loop,
+      extra.opts, paste(
+        '-delay', interval * 100,
+        if (length(interval) == 1) paste(files, collapse = ' ') else files,
+        collapse = ' '),
+      shQuote(movie.name)
+    )
+    # there might be an error "the input line is too long", and we need to quote
+    # the command; see http://stackoverflow.com/q/682799/559676
+    if (.Platform$OS.type == 'windows') convert = sprintf('"%s"', convert)
+    message('Executing: ', strwrap(convert, exdent = 4, prefix = '\n'))
+    if (interactive()) flush.console()
+    cmd = cmd.fun(convert)
+    ## if fails on Windows using shell(), try system() instead of shell()
+    if (cmd != 0 && .Platform$OS.type == 'windows' && identical(cmd.fun, shell)) {
+      cmd = system(convert)
+    }
   }
   if (cmd == 0) {
     message('Output at: ', output)
@@ -162,8 +166,10 @@ gm.convert = function(..., convert = 'gm convert') {
   im.convert(..., convert = convert)
 }
 
-magick.convert <- function(files, output, interval = 1, loop = 0){
+magick.convert <- function(files, output, interval = 1, loop = 0, dispose = NULL){
+  if(!length(dispose))
+    dispose <- "background"
   img <- magick::image_read(files, strip = TRUE)
-  anim <- magick::image_animate(img, loop = loop, fps = 100 / as.integer(interval * 100))
+  anim <- magick::image_animate(img, loop = loop, fps = 100 / as.integer(interval * 100), dispose = dispose)
   magick::image_write(anim, path = output)
 }


### PR DESCRIPTION
See discussion in https://github.com/yihui/animation/issues/85. Use the 'magick' package to convert to gif, which does not require installing and shelling out to im/gm executables.

This prevents all the problems with finding the path to convert and escaping shell arguments. It is a bit faster too. Here is a quick benchmark:

```r
test <- function(){
  for(i in 1:10)
    plot(rnorm(i))
}

library(animation)
library(microbenchmark)
microbenchmark(
  magick = saveGIF(test(), convert = 'magick'),
  convert = saveGIF(test(), convert = 'convert'),
  times = 20)

## Unit: milliseconds
##    expr      min       lq     mean   median       uq      max neval cld
##  magick 443.3866 457.8364 477.4666 473.2199 481.5450 582.4752    20  a 
## convert 534.5049 553.7037 569.6321 566.7770 575.9479 664.3616    20   b
```