### PR TITLE
docs: Remove unimplemented verbose feature from docs

### DIFF
--- a/R/ani.options.R
+++ b/R/ani.options.R
@@ -23,11 +23,11 @@
 #'   if a positive integer. Also used for units other than the default,
 #'   and to convert points to pixels.;
 #'   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
-#'   
-#'   \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
-#'   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
-#'   \code{\link{saveSWF}} is not included, 
-#'   it allows user to define the C-style string format for output image. 
+#'
+#'   \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}},
+#'   \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}},
+#'   \code{\link{saveSWF}} is not included,
+#'   it allows user to define the C-style string format for output image.
 #'   }
 #'
 #'   \item{imgdir}{character: the name of the directory (a relative path) for
@@ -47,9 +47,8 @@
 #'   \item{title, description}{character: the title and description of the
 #'   animation in the HTML page created by \code{\link{saveHTML}}}
 #'
-#'   \item{verbose}{ logical or character: if \code{TRUE}, write a footer part
-#'   in the HTML page containing detailed technical information; if given a
-#'   character string, it will be used as the footer message; in other cases,
+#'   \item{verbose}{logical: if \code{TRUE}, write a footer part
+#'   in the HTML page containing detailed technical information else
 #'   the footer of the page will be blank.}
 #'
 #'   \item{loop}{logical or numeric: Number of times the GIF animation is to

--- a/man/ani.options.Rd
+++ b/man/ani.options.Rd
@@ -64,11 +64,11 @@ Please note that \code{nmax} is not always equal to the number of
   if a positive integer. Also used for units other than the default,
   and to convert points to pixels.;
   see graphics devices like \code{\link{png}}, \code{\link{jpeg}}.}
-  
-  \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}}, 
-  \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}}, 
-  \code{\link{saveSWF}} is not included, 
-  it allows user to define the C-style string format for output image. 
+
+  \item{imgnfmt}{ Customizing image number format in \code{\link{saveHTML}},
+  \code{\link{saveGIF}}, \code{\link{saveLatex}} and \code{\link{saveVideo}},
+  \code{\link{saveSWF}} is not included,
+  it allows user to define the C-style string format for output image.
   }
 
   \item{imgdir}{character: the name of the directory (a relative path) for
@@ -88,9 +88,8 @@ Please note that \code{nmax} is not always equal to the number of
   \item{title, description}{character: the title and description of the
   animation in the HTML page created by \code{\link{saveHTML}}}
 
-  \item{verbose}{ logical or character: if \code{TRUE}, write a footer part
-  in the HTML page containing detailed technical information; if given a
-  character string, it will be used as the footer message; in other cases,
+  \item{verbose}{logical: if \code{TRUE}, write a footer part
+  in the HTML page containing detailed technical information else
   the footer of the page will be blank.}
 
   \item{loop}{logical or numeric: Number of times the GIF animation is to


### PR DESCRIPTION
* Looking at the code and from experimentation it looks like the character value argument to ``verbose`` argument feature documented in ``ani.options`` (can specify one owns footer text) is not actually implemented in ``Rweb.R`` nor ``saveHTML.R``, this removes the documentation implying that that feature is implemented.