### PR TITLE
fix: Support 'ani.res' for arbitrary graphic devices

### DIFF
--- a/R/saveGIF.R
+++ b/R/saveGIF.R
@@ -85,11 +85,9 @@ saveGIF = function(
   img.fmt = paste(img.name, ani.options('imgnfmt'), '.', file.ext, sep = '')
 
   if ((use.dev <- ani.options('use.dev'))){
-    if (is.character(ani.options('ani.dev')) &&
-        any(grepl(ani.options('ani.dev'), c("png", "bmp", "jpeg", "tiff")))){
+    if ("res" %in% names(formals(ani.dev))){
       ani.dev(file.path(tempdir(), img.fmt), width = ani.options('ani.width'),
               height = ani.options('ani.height'), res = ani.options('ani.res'))
-      # ,bg = ani.options('ani.bg')
     } else {
       ani.dev(file.path(tempdir(), img.fmt), width = ani.options('ani.width'),
               height = ani.options('ani.height'))

--- a/R/saveHTML.R
+++ b/R/saveHTML.R
@@ -133,8 +133,7 @@ saveHTML = function(
   img.fmt = file.path(imgdir, paste(img.name, ani.options('imgnfmt'), '.', ani.type, sep = ''))
   ani.options(img.fmt = img.fmt)
   if ((use.dev <- ani.options('use.dev'))) {
-    if (is.character(ani.options('ani.dev')) &&
-        any(grepl(ani.options('ani.dev'), c("png", "bmp", "jpeg", "tiff")))) {
+    if ("res" %in% names(formals(ani.dev))){
       ani.dev(img.fmt, width = ani.options('ani.width'),
               height = ani.options('ani.height'), res = ani.options('ani.res'))
     } else {

--- a/R/saveVideo.R
+++ b/R/saveVideo.R
@@ -74,8 +74,7 @@ saveVideo = function(
   img.fmt = file.path(tempdir(), img.fmt)
   ani.options(img.fmt = img.fmt)
   if ((use.dev <- ani.options('use.dev'))) {
-    if (is.character(ani.options('ani.dev')) &&
-        any(grepl(ani.options('ani.dev'), c("png", "bmp", "jpeg", "tiff")))) {
+    if ("res" %in% names(formals(ani.dev))){
       ani.dev(img.fmt, width = ani.options('ani.width'),
               height = ani.options('ani.height'), res = ani.options('ani.res'))
     } else {


### PR DESCRIPTION
* Add support for 'ani.res' for arbitrary graphic devices
  in 'saveGIF()', 'saveHTML()', and 'saveVideo()'.
* Should work for any graphic device function with 'res'
  as an argument.  In particular should continue to support R's built-in
  raster image format devices passed as strings as well as now supporting 'ragg::agg_png()'
  and R's built-in devices passed in as a function instead of string.
* Still no 'ani.res' support in 'saveLatex()' ('pdf' devices recommended)
  nor 'saveSWF()' (flash no longer supported in many browsers)

closes #134